### PR TITLE
added .rst to the list of default extensions

### DIFF
--- a/SublimeWritingStyle.sublime-settings
+++ b/SublimeWritingStyle.sublime-settings
@@ -35,6 +35,6 @@
 	],
 	// "\\b\\(am\\|are\\|were\\|being\\|is\\|been\\|was\\|be\\)\\b\\([[:space:]]\\|\\s<\\|\\s>\\)+\\([[:word:]]+ed\\|"
 	"passive_voice_linking_verbs": ["am", "are", "were", "being", "is", "been", "was", "be"],
-	"extensions": [".py", ".tex", ".md", ".mdown", ".markdown", ".txt"],
+	"extensions": [".py", ".tex", ".md", ".mdown", ".markdown", ".txt", ".rst"],
 	"enabled": true
 }


### PR DESCRIPTION
Restructured text is the default choice for documents written with [sphinx](http://sphinx-doc.org/rest.html), which most python projects use. I think it's reasonable to support it by default..
